### PR TITLE
bump parking-lot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ readme = "README.md"
 keywords = ["semaphore", "concurrency", "atomic"]
 
 [dependencies]
-parking_lot = "0.4.8"
+parking_lot = "0.6"


### PR DESCRIPTION
No-change upgrade of `parking-lot`. Tests are green on linux/amd64.